### PR TITLE
feat: enable blockexplorer always when handler is notified

### DIFF
--- a/roles/vega_core/handlers/main.yaml
+++ b/roles/vega_core/handlers/main.yaml
@@ -10,7 +10,9 @@
 
 - name: Restart blockexplorer
   ansible.builtin.service:
-    state: "{{- 'restarted' if vega_core_run_network else 'stopped' -}}"
+    # it may be started anytime and during first startup it initialize the database, 
+    # so it should be started as soon as possible ideally before the vegavisor
+    state: "started"
     daemon_reload: true
     enabled: true
     name: blockexplorer

--- a/roles/vega_core/handlers/main.yaml
+++ b/roles/vega_core/handlers/main.yaml
@@ -10,7 +10,7 @@
 
 - name: Restart blockexplorer
   ansible.builtin.service:
-    # it may be started anytime and during first startup it initialize the database, 
+    # it may be started anytime and during first startup it initialize the database,
     # so it should be started as soon as possible ideally before the vegavisor
     state: "started"
     daemon_reload: true


### PR DESCRIPTION
We should do it because when block explorer is started after vegavisor, the DB is missing and tendermint is unable to save data there