### PR TITLE
feat: do not install candles-api if an external release process is involved

### DIFF
--- a/roles/candles_api/defaults/main.yaml
+++ b/roles/candles_api/defaults/main.yaml
@@ -6,3 +6,4 @@ candles_api_polygonio_api_key: ""
 candles_api_with_caddy_config: false
 candles_api_caddy_config_destination: /etc/caddy/sites/candles-api.caddy
 candles_api_domains: []
+candles_api_external_release_enabled: true

--- a/roles/candles_api/tasks/main.yaml
+++ b/roles/candles_api/tasks/main.yaml
@@ -13,29 +13,37 @@
     groups: sudo,candles-api
     append: true
 
-- name: Download candles-api binary
-  ansible.builtin.get_url:
-    force: true
-    url: "https://github.com/{{- candles_api_binary_repository -}}/releases/download/{{- candles_api_binary_version -}}/candles-api-linux-amd64.zip"
-    dest: &bin_dest /tmp/candles_api.zip
-    mode: '0600'
+- name: Check if candles-api already installed
+  ansible.builtin.stat:
+    path: /usr/local/bin/candles-api
+  register: candles_api_installed
 
-- name: Unpack candles-api
-  ansible.builtin.unarchive:
-    src: *bin_dest
-    remote_src: true
-    dest: /tmp
-  when: not ansible_check_mode
+- name: Install candles-api
+  when: not candles_api_external_release_enabled or not candles_api_installed.stat.exists
+  block:
+    - name: Download candles-api binary
+      ansible.builtin.get_url:
+        force: true
+        url: "https://github.com/{{- candles_api_binary_repository -}}/releases/download/{{- candles_api_binary_version -}}/candles-api-linux-amd64.zip"
+        dest: &bin_dest /tmp/candles_api.zip
+        mode: '0600'
 
-- name: Copy candles-api binary
-  ansible.builtin.copy:
-    remote_src: true
-    src: "/tmp/candles-api-linux-amd64"
-    dest: /usr/local/bin/candles-api
-    owner: root
-    group: root
-    mode: '0755'
-  when: not ansible_check_mode
+    - name: Unpack candles-api
+      ansible.builtin.unarchive:
+        src: *bin_dest
+        remote_src: true
+        dest: /tmp
+      when: not ansible_check_mode
+
+    - name: Copy candles-api binary
+      ansible.builtin.copy:
+        remote_src: true
+        src: "/tmp/candles-api-linux-amd64"
+        dest: /usr/local/bin/candles-api
+        owner: root
+        group: root
+        mode: '0755'
+      when: not ansible_check_mode
 
 - name: Install candles-api systemd files
   ansible.builtin.template:

--- a/roles/docker/tasks/main.yaml
+++ b/roles/docker/tasks/main.yaml
@@ -40,9 +40,11 @@
   delay: 3
   register: docker_apt_result
   until: docker_apt_result is succeeded
+  when: not ansible_check_mode
 
 - name: Restart docker
   ansible.builtin.systemd:
     state: restarted
     daemon_reload: true
     name: docker
+  when: not ansible_check_mode

--- a/roles/pyth_price_scheduler/tasks/process-watcher.yaml
+++ b/roles/pyth_price_scheduler/tasks/process-watcher.yaml
@@ -10,6 +10,7 @@
     src: *watcherdist
     remote_src: true
     dest: /tmp
+  when: not ansible_check_mode
 
 - name: Copy the binary
   ansible.builtin.copy:
@@ -19,6 +20,7 @@
     owner: root
     group: root
     mode: '0755'
+  when: not ansible_check_mode
 
 - name: Copy process watcher config
   ansible.builtin.template:
@@ -27,6 +29,7 @@
     owner: root
     group: root
     mode: '0644'
+  when: not ansible_check_mode
 
 - name: Copy process watcher service file
   ansible.builtin.template:
@@ -35,6 +38,7 @@
     owner: root
     group: root
     mode: '0644'
+  when: not ansible_check_mode
 
 - name: Start pusher watcher service
   ansible.builtin.service:
@@ -42,3 +46,4 @@
     state: restarted
     enabled: true
     daemon_reload: true
+  when: not ansible_check_mode


### PR DESCRIPTION
# Changes

- do not install candles-api if an external release process is involved
- Do not run specific steps in ansible-check-mode